### PR TITLE
Allow cross-org server diffs

### DIFF
--- a/util.py
+++ b/util.py
@@ -2489,18 +2489,12 @@ def get_component_attribute(file_name):
     """
     # Get toolingapi settings
     settings = context.get_settings()
-
     # Check whether current file is subscribed component
     attributes = get_file_attributes(file_name)
     metadata_folder = attributes["metadata_folder"]
     name = attributes["name"]
     fullName = attributes["fullName"]
     if metadata_folder not in settings["all_metadata_folders"]:
-        return None, None
-
-    # Check whether project of current file is active project
-    default_project_name = settings["default_project_name"]
-    if default_project_name.lower() not in file_name.lower(): 
         return None, None
 
     xml_name = settings[metadata_folder]["xmlName"]


### PR DESCRIPTION
This resolves issue #61 .  In release v3.1.4 you added logic to `get_component_attribute(file_name)` that checks if the component belongs to the active project.  This logic prevented me from running "diff with server" on a file that exists in two different salesforce orgs.

For example: I have a production org call "reyesml Production" and a sandbox called "reyesml Sandbox", and both orgs have a file called "MyCustomController.cls".

In haoide v3.1.3 i could have "reyesml Sandbox" as the active project, and I could diff MyCustomController against both the "reyesml Sandbox" server and the "reyesml Production" server.

In haoide v3.1.4 (and up), I can only diff MyCustomController against the active project.  If i attempt to diff against an inactive project, I receive the `This component is not exist in chosen project` error.