### PR TITLE
Add New Capability of Save Lightning Components to Server

### DIFF
--- a/aura.py
+++ b/aura.py
@@ -26,11 +26,12 @@ class OpenAuraDocumentReference(sublime_plugin.WindowCommand):
         
         return True
 
+
 class DeployLightingToServer(sublime_plugin.WindowCommand):
     def __init__(self, *args, **kwargs):
         super(DeployLightingToServer, self).__init__(*args, **kwargs)
 
-    def run(self, dirs, switch_project=True, source_org=None):
+    def run(self, dirs, switch_project=True, source_org=None, element=None, update_meta=False):
         if switch_project:
             return self.window.run_command("switch_project", {
                 "callback_options": {
@@ -38,13 +39,15 @@ class DeployLightingToServer(sublime_plugin.WindowCommand):
                     "args": {
                         "switch_project": False,
                         "source_org": self.settings["default_project_name"],
-                        "dirs": dirs
+                        "dirs": dirs,
+                        "element": element,
+                        "update_meta": update_meta
                     }
                 }
             })
 
         base64_package = util.build_aura_package(dirs)
-        processor.handle_deploy_thread(base64_package, source_org=source_org)
+        processor.handle_deploy_thread(base64_package, source_org=source_org, element=element, update_meta=update_meta)
 
     def is_visible(self, dirs, switch_project=True):
         if not dirs or len(dirs) == 0: return False
@@ -228,7 +231,9 @@ class CreateLightingElement(sublime_plugin.WindowCommand):
         # Deploy Aura to server
         self.window.run_command("deploy_lighting_to_server", {
             "dirs": [self._dir],
-            "switch_project": False
+            "switch_project": False,
+            "element": element,
+            "update_meta": True
         })
 
     def is_visible(self, dirs, element=""):
@@ -312,7 +317,9 @@ class CreateLightingDefinition(sublime_plugin.WindowCommand):
         # Deploy Aura to server
         self.window.run_command("deploy_lighting_to_server", {
             "dirs": [component_dir],
-            "switch_project": False
+            "switch_project": False,
+            "element": self._type,
+            "update_meta": True
         })
 
     def is_enabled(self):

--- a/config/snippets/Apex/Class Header - class header.sublime-snippet
+++ b/config/snippets/Apex/Class Header - class header.sublime-snippet
@@ -5,9 +5,9 @@
  * Object: $2
  * Purpose: $3
  * Author: $4 ($5)
- * Create Date: 2018-${6:01-07}
+ * Create Date: 2018-${6:05-07}
  * Modify History:
- * 2018-${6:01-07}    $4    ${7:Create this class}
+ * 2018-${6:05-07}    $4    ${7:Create this class}
  **************************************************************************************************/
 ]]></content>
     <tabTrigger>ch</tabTrigger>

--- a/config/templates/templates.json
+++ b/config/templates/templates.json
@@ -111,7 +111,7 @@
         "Apex REST": {
             "directory": "ApexClass/Apex REST.cls",
             "extension": ".cls",
-            "description": "Exception Class"
+            "description": "REST Class"
         },
         "Test": {
             "directory": "ApexClass/Test.cls",

--- a/context.py
+++ b/context.py
@@ -8,6 +8,19 @@ from .salesforce.lib.panel import Printer
 
 COMPONENT_METADATA_SETTINGS = "component_metadata.sublime-settings"
 TOOLING_API_SETTINGS = "toolingapi.sublime-settings"
+EXT_DICT = {
+        'application': '.app',
+        'controller': 'controller.js',
+        'component': '.cmp',
+        'event': '.evt',
+        'helper': 'helper.js',
+        'interface': '.intf',
+        'renderer': 'renderer.js',
+        'style': '.css',
+        'documentation': '.auradoc',
+        'design': '.design',
+        'svg': '.svg'
+    }
 
 def get_settings():
     """ Load all settings in toolingapi.sublime-settings

--- a/main.py
+++ b/main.py
@@ -2190,7 +2190,7 @@ class SaveToServer(sublime_plugin.TextCommand):
     def is_enabled(self):
         if not self.view or not self.view.file_name(): return False
         attributes = util.get_file_attributes(self.view.file_name())
-        if attributes["metadata_folder"] not in ["classes", "components", "pages", "triggers"]:
+        if attributes["metadata_folder"] not in ["classes", "components", "pages", "triggers", "aura"]:
             return False
             
         return util.check_enabled(self.view.file_name())

--- a/processor.py
+++ b/processor.py
@@ -1503,8 +1503,9 @@ def handle_save_to_server(file_name, is_check_only=False, timeout=120):
             Printer.get('log').write("%s %s successfully" % (save_or_compile, file_base_name))
 
             # Add total seconds message
-            total_seconds = (datetime.datetime.now() - start_time).seconds
-            Printer.get('log').write("\nTotal time: %s seconds" % total_seconds, False)
+            dt = datetime.datetime.now() - start_time
+            total_seconds = dt.seconds + dt.microseconds / 1e6
+            Printer.get('log').write("\nTotal time: %.2f seconds" % total_seconds, False)
 
             # Remove highlight
             view = util.get_view_by_file_name(file_name)
@@ -1602,8 +1603,12 @@ def handle_save_to_server(file_name, is_check_only=False, timeout=120):
     Printer.get('log').write_start().write("Start to %s %s" % (compile_or_save, file_base_name))
 
     api = ToolingApi(settings)
-    thread = threading.Thread(target=api.save_to_server,
-        args=(component_attribute, body, is_check_only, ))
+    if component_attribute["type"] in ["AuraDefinitionBundle", "AuraDefinition"]:
+        target = api.save_aura_to_server
+    else:
+        target = api.save_to_server
+    thread = threading.Thread(target=target,
+                              args=(component_attribute, body, is_check_only, ))
     thread.start()
 
     # If saving thread is started, set the flag to True

--- a/processor.py
+++ b/processor.py
@@ -563,7 +563,7 @@ def handle_destructive_package_xml(types, timeout=120):
     handle_thread(thread, timeout)
 
 def handle_deploy_thread(base64_encoded_zip, 
-        source_org=None, chosen_classes=[], timeout=120):
+        source_org=None, element=None, chosen_classes=[], timeout=120, update_meta=False):
     def handle_thread(thread, timeout=120):
         if thread.is_alive():
             sublime.set_timeout(lambda:handle_thread(thread, timeout), timeout)
@@ -572,6 +572,11 @@ def handle_deploy_thread(base64_encoded_zip,
         # If source_org is not None, we need to switch project back
         if settings["switch_back_after_migration"] and source_org:
             util.switch_project(source_org)
+
+        result = api.result
+        body = result["body"]
+        if body["status"] == "Succeeded" and update_meta:
+            handle_update_aura_meta(body, element)
 
     settings = context.get_settings()
     api = MetadataApi(settings)
@@ -583,6 +588,77 @@ def handle_deploy_thread(base64_encoded_zip,
     ThreadProgress(api, thread, "Deploy Metadata to %s" % settings["default_project_name"], 
         "Metadata Deployment Finished")
     handle_thread(thread, timeout)
+
+
+def handle_update_aura_meta(body, element, timeout=120, type = "AuraDefinitionBundle"):
+    """
+
+    :param body: body data returned from SOAP API
+    :param element: Aura type in `COMPONENT`, `CONTROLLER`, `HELPER`, `SVG`...
+    :param timeout: timeout in second
+    :param type: type
+    :return:
+    """
+    def handle_thread(thread, full_name, timeout):
+        if thread.is_alive():
+            sublime.set_timeout(lambda: handle_thread(thread, full_name, timeout), timeout)
+            return
+
+        result = api.result
+        if not result or not result["success"]:
+            return
+
+        if result["totalSize"] == 0:
+            Printer.get("log").write("There is no component data")
+            return
+        elif result["totalSize"] == 1:
+            record = result["records"][0]
+            cmp_meta = {
+                "name": full_name[:full_name.find('.')],
+                "extension": full_name[full_name.find('.'):],
+                "id": record["Id"],
+                "lastModifiedDate": record["LastModifiedDate"],
+                "type": "AuraDefinitionBundle",
+                "DefType": record["DefType"]
+            }
+            components_dict[type][full_name.lower()] = cmp_meta
+            s.set(username, components_dict)
+            sublime.save_settings(context.COMPONENT_METADATA_SETTINGS)
+
+            # Refresh metadata settings
+            sublime.set_timeout(lambda: util.load_metadata_cache(True, settings["username"]), 5)
+
+    settings = context.get_settings()
+    username = settings["username"]
+    s = sublime.load_settings(context.COMPONENT_METADATA_SETTINGS)
+    if not s.has(username):
+        return
+
+    component_successes = body["details"]["componentSuccesses"]
+    if isinstance(component_successes, dict):
+        component_successes = [component_successes]
+
+    for item in component_successes:
+        if item["componentType"] == "AuraDefinitionBundle":
+            base_name = item["fullName"]
+            full_name = base_name + context.EXT_DICT.get(element.lower())
+            components_dict = s.get(username, {})
+
+            # Prevent exception if no component in org
+            if type not in components_dict:
+                components_dict = {type: {}}
+
+            # Build components dict
+            api = ToolingApi(settings)
+            query_str = "SELECT Id, DefType, LastModifiedDate, LastModifiedById " +\
+                "FROM AuraDefinition WHERE AuraDefinitionBundleId = '%s' and DefType = '%s'" % (
+                    item['id'], element.upper())
+            thread = threading.Thread(target=api.query, args=(query_str,))
+            thread.start()
+            ThreadProgress(api, thread, "Update Component Metadata", "Update Component Metadata Finished")
+            handle_thread(thread, full_name, timeout)
+            break
+
 
 def handle_track_all_debug_logs_thread(users, timeout=120):
     settings = context.get_settings()

--- a/util.py
+++ b/util.py
@@ -342,7 +342,7 @@ def populate_all_components():
     username = settings["username"]
 
     # If sobjects is exist in local cache, just return it
-    component_metadata = sublime.load_settings("component_metadata.sublime-settings")
+    component_metadata = sublime.load_settings(context.COMPONENT_METADATA_SETTINGS)
     if not component_metadata.has(username):
         Printer.get('error').write("No Cache, Please New Project Firstly.")
         return {}
@@ -373,7 +373,7 @@ def populate_components(_type):
     username = settings["username"]
 
     # If sobjects is exist in local cache, just return it
-    component_settings = sublime.load_settings("component_metadata.sublime-settings")
+    component_settings = sublime.load_settings(context.COMPONENT_METADATA_SETTINGS)
     if not component_settings.has(username):
         message = "Please execute `Cache > Reload Sobject Cache` command before execute this command"
         Printer.get("error").write(message)
@@ -387,7 +387,7 @@ def populate_lighting_applications():
     workspace = settings["workspace"]
     username = settings["username"]
     aura_path = os.path.join(workspace, "src", "aura")
-    component_settings = sublime.load_settings("component_metadata.sublime-settings")
+    component_settings = sublime.load_settings(context.COMPONENT_METADATA_SETTINGS)
     if not component_settings.has(username):
         return {}
 
@@ -430,7 +430,7 @@ def populate_all_test_classes():
     settings = context.get_settings()
     username = settings["username"]
 
-    component_metadata = sublime.load_settings("component_metadata.sublime-settings")
+    component_metadata = sublime.load_settings(context.COMPONENT_METADATA_SETTINGS)
     if not component_metadata.has(username):
         Printer.get('error').write("No cache, please create new project firstly.")
         return
@@ -455,7 +455,7 @@ def set_component_attribute(attributes, lastModifiedDate):
     # If sobjects is exist in local cache, just return it
     settings = context.get_settings()
     username = settings["username"]
-    s = sublime.load_settings("component_metadata.sublime-settings")
+    s = sublime.load_settings(context.COMPONENT_METADATA_SETTINGS)
     if not s.has(username):
         return
 
@@ -474,7 +474,7 @@ def set_component_attribute(attributes, lastModifiedDate):
 
     # Save settings and show success message
     s.set(username, components_dict)
-    sublime.save_settings("component_metadata.sublime-settings")
+    sublime.save_settings(context.COMPONENT_METADATA_SETTINGS)
 
 
 def get_sobject_caches(setting_name):


### PR DESCRIPTION
Now developers can save lightning components such as application/component markup, controller, helper, etc.directly to Salesforce just like they did for Apex classes, pages and triggers.

Mostly, it's quiet fast than deploy to server!

Also added functionality of updating lightning components after the creating, fixed typo of lightning, updated class header snippet date