### PR TITLE
Fixed bug #128: HTTP method 'GET' not allowed on Run Sync Test

### DIFF
--- a/main.py
+++ b/main.py
@@ -1598,7 +1598,13 @@ class RunSyncTests(sublime_plugin.WindowCommand):
 
 class RunSyncTest(sublime_plugin.TextCommand):
     def run(self, edit):
-        processor.handle_run_sync_test([self.cname])
+        tests = [];
+        for region in self.view.sel():
+            sel = self.view.substr(self.view.word(region.begin()))
+            if sel and not sel.isspace():
+                tests.append(sel.strip())
+
+        processor.handle_run_sync_test([self.cname], tests)
 
     def is_enabled(self):
         # Get current file name and Read file content
@@ -1623,6 +1629,11 @@ class RunSyncTest(sublime_plugin.TextCommand):
                 component_attribute["namespacePrefix"],
                 self.cname
             )
+            
+        for region in self.view.sel():
+            sel = self.view.substr(self.view.word(region.begin()))
+            if sel and not sel.isspace() and not re.compile(r'^[a-zA-Z0-9_]*$').match(sel.strip()):
+                return False
             
         return True
 

--- a/processor.py
+++ b/processor.py
@@ -1159,7 +1159,7 @@ def handle_run_test(class_name, class_id, timeout=120):
     ThreadProgress(api, thread, "Run Test Class " + class_name, "Run Test for " + class_name + " Succeed")
     handle_thread(thread, timeout)
 
-def handle_run_sync_test(class_names, timeout=120):
+def handle_run_sync_test(class_names, test_names, timeout=120):
     def handle_thread(thread, timeout):
         if thread.is_alive():
             sublime.set_timeout(lambda: handle_thread(thread, timeout), timeout)
@@ -1209,7 +1209,7 @@ def handle_run_sync_test(class_names, timeout=120):
 
     settings = context.get_settings()
     api = ToolingApi(settings)
-    thread = threading.Thread(target=api.run_tests_synchronous, args=(class_names, ))
+    thread = threading.Thread(target=api.run_tests_synchronous, args=(class_names[0], test_names))
     thread.start()
     wait_message = "Running Sync Test Classes%s" % (
         " for %s" % class_names[0] if len(class_names) == 1 else ""

--- a/salesforce/api/tooling.py
+++ b/salesforce/api/tooling.py
@@ -829,15 +829,19 @@ class ToolingApi():
         self.result = self.get(url)
         return self.result
 
-    def run_tests_synchronous(self, class_names):
-        """ Run synchronous test for specified class ids
+    def run_tests_synchronous(self, class_name, test_names):
+        """ Run synchronous test for specified class names
 
         Arguments:
 
-        * class_names -- Apex Test Class Name List
+        * class_name -- Apex Test Class Name
+        * test_names -- Apex Test Method Name List
         """
-        url = "/tooling/runTestsSynchronous/?classnames=" + ",".join(class_names)
-        self.result = self.get(url)
+        if test_names and len(test_names) > 0:
+            data = {"tests":[{"className":class_name,"testMethods":test_names}]}
+        else:
+            data = {"tests":[{"className":class_name}]}
+        self.result = self.post("/tooling/runTestsSynchronous/", data)
         return self.result
 
     def run_test(self, class_id):


### PR DESCRIPTION
Run Sync Test now executes an HTTP POST rather than a GET.

Executing Run Sync Test when one or more test method names are selected will now run apex tests for those methods only.  This is useful when only the coverage for the specific tests are desired.  If no test methods are selected all tests within the test class are run.